### PR TITLE
Show Offering for realm

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,3 +17,13 @@ body {
     align-items: center;
     overflow: hidden;
 }
+
+#realm-name {
+    font-weight: bold;
+}
+
+.flex-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
         <h1 id="realm-name" class="d-flex justify-content-center flex-nowrap">?????????</h1>
         <img id="realm-image" src="./images/realms/Unknown.webp" class="d-flex justify-content-center flex-nowrap"
              alt="An image of the realm"/>
+        <div class="flex-container">
+            <img id="offering-image" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>
+            <h3 id="offering-name">?????????</h3>
+<!--            <img id="offering-image1" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>-->
+<!--            <img id="offering-image2" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>-->
+<!--            <h3>Azarovs Key</h3>-->
+        </div>
         <button id="randomize-button" type="submit" class="button" title="Randomly select a new realm">
             <span class="button__text">Randomize</span>
         </button>
@@ -26,6 +33,7 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
         crossorigin="anonymous"></script>
-<script src="./js/random-realm.js"></script>
+<script type="module" src="./js/random-realm.js"></script>
+<script type="module" src="js/realmRepo.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,6 @@
         <div class="flex-container">
             <img id="offering-image" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>
             <h3 id="offering-name">?????????</h3>
-<!--            <img id="offering-image1" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>-->
-<!--            <img id="offering-image2" src="./images/offerings/Unknown.webp" alt="An image of the offering that spawns the realm" width="80" height="80"/>-->
-<!--            <h3>Azarovs Key</h3>-->
         </div>
         <button id="randomize-button" type="submit" class="button" title="Randomly select a new realm">
             <span class="button__text">Randomize</span>

--- a/js/random-realm.js
+++ b/js/random-realm.js
@@ -1,29 +1,14 @@
+import {RealmRepo} from "./realmRepo.js";
+
 class Randomizer {
-    IMAGE_PATH = "./images/realms/";
-
-    realms = {
-        "Garden Of Joy": "Garden_Of_Joy.webp",
-        "Forsaken Boneyard": "Forsaken_Boneyard.webp",
-        "Raccoon City": "Raccoon_City.webp",
-        "Silent Hill": "Silent_Hill.webp",
-        "Grave of Glenvale": "Grave_Of_Glenvale.webp",
-        "Yamaoka Estate": "Yamaoka_Estate.webp",
-        "Red Forest": "Red_Forest.webp",
-        "Ormond": "Ormond.webp",
-        "Gideon Meat Plant": "Gideon_Meat_Plant.webp",
-        "Springwoood": "Springwood.webp",
-        "Léry's Memorial Institute": "Lerys_Memorial_Institute.webp",
-        "Backwater Swamp": "Backwater_Swamp.webp",
-        "Haddonfield": "Haddonfield.webp",
-        "Crotus Prenn Asylum": "Crotus_Prenn_Asylum.webp",
-        "Autohaven Wreckers": "Autohaven_Wreckers.webp",
-        "The MacMillan Estate": "The_MacMillan_Estate.webp",
-        "Coldwind Farm": "Coldwind_Farm.webp"
-    }
-
-    realmNames = Object.keys(this.realms);
     randomizationInProgress = false;
     currentRealm = null;
+
+    constructor() {
+        this.realmRepo = new RealmRepo();
+        this.realmNames = this.realmRepo.getAllRealmNames();
+        this.initEventListeners();
+    }
 
     /**
      * Selects a new random realm with a 1-second delay.
@@ -56,19 +41,33 @@ class Randomizer {
     }
 
     /**
-     * Select a random realm and update realm fields.
+     * Select a random realm and update realm and offering fields.
      * The same realm will not be selected sequentially.
      */
     updateRealm() {
         const realmName = document.getElementById("realm-name");
         const realmImage = document.getElementById("realm-image");
+        const offeringName = document.getElementById("offering-name");
+        const offeringImage = document.getElementById("offering-image");
+        const newRealm = this.getRandomRealmName();
+
+        realmName.innerText = newRealm;
+        realmImage.src = this.realmRepo.getRealmImagePath(newRealm);
+        offeringName.innerText = this.realmRepo.getOfferingName(newRealm);
+        offeringImage.src = this.realmRepo.getOfferingImagePath(newRealm);
+
+        this.currentRealm = newRealm;
+    }
+
+    /**
+     * Returns a random realm name - will not return current realm.
+     */
+    getRandomRealmName() {
         let newRealm = this.realmNames[this.getRandomInt(0, this.realmNames.length - 1)];
         while (this.currentRealm === newRealm) {
             newRealm = this.realmNames[this.getRandomInt(0, this.realmNames.length - 1)];
         }
-        realmName.innerText = newRealm;
-        realmImage.src = this.IMAGE_PATH + this.realms[newRealm];
-        this.currentRealm = newRealm;
+        return newRealm;
     }
 
     /**
@@ -78,15 +77,17 @@ class Randomizer {
         return Math.floor(Math.random() * (max - min + 1)) + min;
     }
 
-
-    init() {
+    /**
+     * Initialise event listeners for UI components.
+     * Currently, this only applies to the randomize button.
+     */
+    initEventListeners() {
         const randomizeButton = document.getElementById("randomize-button");
         randomizeButton.addEventListener("click", this.processRandomizeButtonClick);
     }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-    const randomizer = new Randomizer();
-    randomizer.init();
+    new Randomizer();
 });
 

--- a/js/realmRepo.js
+++ b/js/realmRepo.js
@@ -1,0 +1,209 @@
+
+export class RealmRepo {
+    REALM_IMAGE_PATH = "./images/realms/";
+    OFFERING_IMAGE_PATH = "./images/offerings/";
+
+    forsaken_boneyard = {
+        name: "Forsaken Boneyard",
+        realm_image: "Forsaken_Boneyard.webp",
+        offering_name: "Crows Eye",
+        offering_image: "ForsakenBoneyard_CrowsEye.webp"
+    };
+
+    raccoon_city = {
+        name: "Raccoon City",
+        realm_image: "Raccoon_City.webp",
+        offering_name: "RPD Badge",
+        offering_image: "RaccoonCity_RpdBadge.webp"
+    };
+
+    silent_hill = {
+        name: "Silent Hill",
+        realm_image: "Silent_Hill.webp",
+        offering_name: "Mary's Letter",
+        offering_image: "SilentHill_MarysLetter.webp"
+    };
+
+    grave_of_glenvale = {
+        name: "Grave Of Glenvale",
+        realm_image: "Grave_Of_Glenvale.webp",
+        offering_name: "Dusty Noose",
+        offering_image: "GraveOfGlenvale_DustyNoose.webp"
+    };
+
+    yamaoka_estate = {
+        name: "Yamaoka Estate",
+        realm_image: "Yamaoka_Estate.webp",
+        offering_name: "Yamaoka Family Crest",
+        offering_image: "YamaokaEstate_YamaokaFamilyCrest.webp"
+    };
+
+    red_forest = {
+        name: "Red Forest",
+        realm_image: "Red_Forest.webp",
+        offering_name: "The Last Mask",
+        offering_image: "RedForest_TheLastMask.webp"
+    };
+
+    ormond = {
+        name: "Ormond",
+        realm_image: "Ormond.webp",
+        offering_name: "Damaged Photo",
+        offering_image: "Ormond_DamagedPhoto.webp"
+    };
+
+    gideon_meat_plant = {
+        name: "Gideon Meat Plant",
+        realm_image: "Gideon_Meat_Plant.webp",
+        offering_name: "Jigsaw Piece",
+        offering_image: "GideonMeatPlant_JigsawPiece.webp"
+    };
+
+    springwood = {
+        name: "Springwood",
+        realm_image: "Springwood.webp",
+        offering_name: "The Pied Piper",
+        offering_image: "Springwood_ThePiedPiper.webp"
+    };
+
+    lerys_memorial_institute = {
+        name: "Léry's Memorial Institute",
+        realm_image: "Lerys_Memorial_Institute.webp",
+        offering_name: "Shattered Glasses",
+        offering_image: "LerysMemorialInstitute_ShatteredGlasses.webp"
+    };
+
+    backwater_swamp = {
+        name: "Backwater Swamp",
+        realm_image: "Backwater_Swamp.webp",
+        offering_name: "Granmas Cookbook",
+        offering_image: "BackwaterSwamp_GranmasCookbook.webp"
+    };
+
+    haddonfield = {
+        name: "Haddonfield",
+        realm_image: "Haddonfield.webp",
+        offering_name: "Strode Realty Key",
+        offering_image: "Haddonfield_StrodeRealtyKey.webp"
+    };
+
+    crotus_prenn_asylum = {
+        name: "Crotus Prenn Asylum",
+        realm_image: "Crotus_Prenn_Asylum.webp",
+        offering_name: "Charred Wedding Photograph",
+        offering_image: "CrotusPrennAsylum_CharredWeddingPhotograph.webp"
+    };
+
+    autohaven_wreckers = {
+        name: "Autohaven Wreckers",
+        realm_image: "Autohaven_Wreckers.webp",
+        offering_name: "Azarov's Key",
+        offering_image: "AutohavenWreckers_AzarovsKey.webp"
+    };
+
+    the_macmillan_estate = {
+        name: "The MacMillan Estate",
+        realm_image: "The_MacMillan_Estate.webp",
+        offering_name: "MacMillan's Phalanx Bone",
+        offering_image: "TheMacMillanEstate_MacMillansPhalanxBone.webp"
+    };
+
+    coldwind_farm = {
+        name: "Coldwind Farm",
+        realm_image: "Coldwind_Farm.webp",
+        offering_name: "Heart Locket",
+        offering_image: "ColdwindFarm_HeartLocket.webp"
+    };
+
+    withered_isle = {
+        name: "Withered Isle",
+        realm_image: "Withered_Isle.webp",
+        offering_name: "Ichorous Loam",
+        offering_image: "WitheredIsle_IchorousLoam.webp"
+    }
+
+    unknown = {
+        name: "Unknown",
+        realm_image: "Unknown.webp",
+        offering_name: "Unknown",
+        offering_image: "Unknown.webp"
+    }
+
+    realms = {
+        "Forsaken Boneyard": this.forsaken_boneyard,
+        "Raccoon City": this.raccoon_city,
+        "Silent Hill": this.silent_hill,
+        "Grave of Glenvale": this.grave_of_glenvale,
+        "Yamaoka Estate": this.yamaoka_estate,
+        "Red Forest": this.red_forest,
+        "Ormond": this.ormond,
+        "Gideon Meat Plant": this.gideon_meat_plant,
+        "Springwoood": this.springwood,
+        "Léry's Memorial Institute": this.lerys_memorial_institute,
+        "Backwater Swamp": this.backwater_swamp,
+        "Haddonfield": this.haddonfield,
+        "Crotus Prenn Asylum": this.crotus_prenn_asylum,
+        "Autohaven Wreckers": this.autohaven_wreckers,
+        "The MacMillan Estate": this.the_macmillan_estate,
+        "Coldwind Farm": this.coldwind_farm,
+        "Withered Isle": this.withered_isle,
+    };
+
+    getAllRealmNames() {
+        return Object.keys(this.realms);
+    }
+
+    getRealm(name) {
+        return this.realms[name];
+    }
+
+    getRealmImage(realmName) {
+        if (realmName in this.realms) {
+            return this.realms[realmName]["realm_image"];
+        }
+        else {
+            return this.unknown["realm_image"];
+        }
+    }
+
+    getRealmImagePath(realmName) {
+        let image;
+        if (realmName in this.realms) {
+            image = this.realms[realmName]["realm_image"];
+        }
+        else {
+            image = this.unknown["realm_image"];
+        }
+        return this.REALM_IMAGE_PATH + image;
+    }
+
+    getOfferingName(realmName) {
+        if (realmName in this.realms) {
+            return this.realms[realmName]["offering_name"];
+        }
+        else {
+            return this.unknown["offering_name"];
+        }
+    }
+
+    getOfferingImage(realmName) {
+        if (realmName in this.realms) {
+            return this.realms[realmName]["offering_image"];
+        }
+        else {
+            return this.unknown["offering_image"];
+        }
+    }
+
+    getOfferingImagePath(realmName) {
+        let image;
+        if (realmName in this.realms) {
+            image = this.realms[realmName]["offering_image"];
+        }
+        else {
+            image = this.unknown["offering_image"];
+        }
+        return this.OFFERING_IMAGE_PATH + image;
+    }
+}
+

--- a/js/realmRepo.js
+++ b/js/realmRepo.js
@@ -1,152 +1,44 @@
-
 export class RealmRepo {
     REALM_IMAGE_PATH = "./images/realms/";
     OFFERING_IMAGE_PATH = "./images/offerings/";
 
-    forsaken_boneyard = {
-        name: "Forsaken Boneyard",
-        realm_image: "Forsaken_Boneyard.webp",
-        offering_name: "Crows Eye",
-        offering_image: "ForsakenBoneyard_CrowsEye.webp"
-    };
-
-    raccoon_city = {
-        name: "Raccoon City",
-        realm_image: "Raccoon_City.webp",
-        offering_name: "RPD Badge",
-        offering_image: "RaccoonCity_RpdBadge.webp"
-    };
-
-    silent_hill = {
-        name: "Silent Hill",
-        realm_image: "Silent_Hill.webp",
-        offering_name: "Mary's Letter",
-        offering_image: "SilentHill_MarysLetter.webp"
-    };
-
-    grave_of_glenvale = {
-        name: "Grave Of Glenvale",
-        realm_image: "Grave_Of_Glenvale.webp",
-        offering_name: "Dusty Noose",
-        offering_image: "GraveOfGlenvale_DustyNoose.webp"
-    };
-
-    yamaoka_estate = {
-        name: "Yamaoka Estate",
-        realm_image: "Yamaoka_Estate.webp",
-        offering_name: "Yamaoka Family Crest",
-        offering_image: "YamaokaEstate_YamaokaFamilyCrest.webp"
-    };
-
-    red_forest = {
-        name: "Red Forest",
-        realm_image: "Red_Forest.webp",
-        offering_name: "The Last Mask",
-        offering_image: "RedForest_TheLastMask.webp"
-    };
-
-    ormond = {
-        name: "Ormond",
-        realm_image: "Ormond.webp",
-        offering_name: "Damaged Photo",
-        offering_image: "Ormond_DamagedPhoto.webp"
-    };
-
-    gideon_meat_plant = {
-        name: "Gideon Meat Plant",
-        realm_image: "Gideon_Meat_Plant.webp",
-        offering_name: "Jigsaw Piece",
-        offering_image: "GideonMeatPlant_JigsawPiece.webp"
-    };
-
-    springwood = {
-        name: "Springwood",
-        realm_image: "Springwood.webp",
-        offering_name: "The Pied Piper",
-        offering_image: "Springwood_ThePiedPiper.webp"
-    };
-
-    lerys_memorial_institute = {
-        name: "Léry's Memorial Institute",
-        realm_image: "Lerys_Memorial_Institute.webp",
-        offering_name: "Shattered Glasses",
-        offering_image: "LerysMemorialInstitute_ShatteredGlasses.webp"
-    };
-
-    backwater_swamp = {
-        name: "Backwater Swamp",
-        realm_image: "Backwater_Swamp.webp",
-        offering_name: "Granmas Cookbook",
-        offering_image: "BackwaterSwamp_GranmasCookbook.webp"
-    };
-
-    haddonfield = {
-        name: "Haddonfield",
-        realm_image: "Haddonfield.webp",
-        offering_name: "Strode Realty Key",
-        offering_image: "Haddonfield_StrodeRealtyKey.webp"
-    };
-
-    crotus_prenn_asylum = {
-        name: "Crotus Prenn Asylum",
-        realm_image: "Crotus_Prenn_Asylum.webp",
-        offering_name: "Charred Wedding Photograph",
-        offering_image: "CrotusPrennAsylum_CharredWeddingPhotograph.webp"
-    };
-
-    autohaven_wreckers = {
-        name: "Autohaven Wreckers",
-        realm_image: "Autohaven_Wreckers.webp",
-        offering_name: "Azarov's Key",
-        offering_image: "AutohavenWreckers_AzarovsKey.webp"
-    };
-
-    the_macmillan_estate = {
-        name: "The MacMillan Estate",
-        realm_image: "The_MacMillan_Estate.webp",
-        offering_name: "MacMillan's Phalanx Bone",
-        offering_image: "TheMacMillanEstate_MacMillansPhalanxBone.webp"
-    };
-
-    coldwind_farm = {
-        name: "Coldwind Farm",
-        realm_image: "Coldwind_Farm.webp",
-        offering_name: "Heart Locket",
-        offering_image: "ColdwindFarm_HeartLocket.webp"
-    };
-
-    withered_isle = {
-        name: "Withered Isle",
-        realm_image: "Withered_Isle.webp",
-        offering_name: "Ichorous Loam",
-        offering_image: "WitheredIsle_IchorousLoam.webp"
-    }
-
-    unknown = {
-        name: "Unknown",
-        realm_image: "Unknown.webp",
-        offering_name: "Unknown",
-        offering_image: "Unknown.webp"
-    }
+    autohaven_wreckers = new Realm("Autohaven Wreckers", "Autohaven_Wreckers.webp", "Azarov's Key", "AutohavenWreckers_AzarovsKey.webp");
+    backwater_swamp = new Realm("Backwater Swamp", "Backwater_Swamp.webp", "Granmas Cookbook", "BackwaterSwamp_GranmasCookbook.webp");
+    coldwind_farm = new Realm("Coldwind Farm", "Coldwind_Farm.webp", "Heart Locket", "ColdwindFarm_HeartLocket.webp");
+    crotus_prenn_asylum = new Realm("Crotus Prenn Asylum", "Crotus_Prenn_Asylum.webp", "Charred Wedding Photograph", "CrotusPrennAsylum_CharredWeddingPhotograph.webp");
+    forsaken_boneyard = new Realm("Forsaken Boneyard", "Forsaken_Boneyard.webp", "Crows Eye", "ForsakenBoneyard_CrowsEye.webp");
+    gideon_meat_plant = new Realm("Gideon Meat Plant", "Gideon_Meat_Plant.webp", "Jigsaw Piece", "GideonMeatPlant_JigsawPiece.webp");
+    grave_of_glenvale = new Realm("Grave Of Glenvale", "Grave_Of_Glenvale.webp", "Dusty Noose", "GraveOfGlenvale_DustyNoose.webp");
+    haddonfield = new Realm("Haddonfield", "Haddonfield.webp", "Strode Realty Key", "Haddonfield_StrodeRealtyKey.webp");
+    lerys_memorial_institute = new Realm("Léry's Memorial Institute", "Lerys_Memorial_Institute.webp", "Shattered Glasses", "LerysMemorialInstitute_ShatteredGlasses.webp");
+    ormond = new Realm("Ormond", "Ormond.webp", "Damaged Photo", "Ormond_DamagedPhoto.webp");
+    raccoon_city = new Realm("Raccoon City", "Raccoon_City.webp", "RPD Badge", "RaccoonCity_RpdBadge.webp");
+    red_forest = new Realm("Red Forest", "Red_Forest.webp", "The Last Mask", "RedForest_TheLastMask.webp");
+    silent_hill = new Realm("Silent Hill", "Silent_Hill.webp", "Mary's Letter", "SilentHill_MarysLetter.webp");
+    springwood = new Realm("Springwood", "Springwood.webp", "The Pied Piper", "Springwood_ThePiedPiper.webp");
+    the_macmillan_estate = new Realm("The MacMillan Estate", "The_MacMillan_Estate.webp", "MacMillan's Phalanx Bone", "TheMacMillanEstate_MacMillansPhalanxBone.webp");
+    withered_isle = new Realm("Withered Isle", "Withered_Isle.webp", "Ichorous Loam", "WitheredIsle_IchorousLoam.webp");
+    yamaoka_estate = new Realm("Yamaoka Estate", "Yamaoka_Estate.webp", "Yamaoka Family Crest", "YamaokaEstate_YamaokaFamilyCrest.webp");
+    unknown = new Realm("Unknown", "Unknown.webp", "Unknown", "Unknown.webp");
 
     realms = {
-        "Forsaken Boneyard": this.forsaken_boneyard,
-        "Raccoon City": this.raccoon_city,
-        "Silent Hill": this.silent_hill,
-        "Grave of Glenvale": this.grave_of_glenvale,
-        "Yamaoka Estate": this.yamaoka_estate,
-        "Red Forest": this.red_forest,
-        "Ormond": this.ormond,
-        "Gideon Meat Plant": this.gideon_meat_plant,
-        "Springwoood": this.springwood,
-        "Léry's Memorial Institute": this.lerys_memorial_institute,
-        "Backwater Swamp": this.backwater_swamp,
-        "Haddonfield": this.haddonfield,
-        "Crotus Prenn Asylum": this.crotus_prenn_asylum,
         "Autohaven Wreckers": this.autohaven_wreckers,
-        "The MacMillan Estate": this.the_macmillan_estate,
+        "Backwater Swamp": this.backwater_swamp,
         "Coldwind Farm": this.coldwind_farm,
+        "Crotus Prenn Asylum": this.crotus_prenn_asylum,
+        "Forsaken Boneyard": this.forsaken_boneyard,
+        "Gideon Meat Plant": this.gideon_meat_plant,
+        "Grave of Glenvale": this.grave_of_glenvale,
+        "Haddonfield": this.haddonfield,
+        "Léry's Memorial Institute": this.lerys_memorial_institute,
+        "Ormond": this.ormond,
+        "Raccoon City": this.raccoon_city,
+        "Red Forest": this.red_forest,
+        "Silent Hill": this.silent_hill,
+        "Springwoood": this.springwood,
+        "The MacMillan Estate": this.the_macmillan_estate,
         "Withered Isle": this.withered_isle,
+        "Yamaoka Estate": this.yamaoka_estate
     };
 
     getAllRealmNames() {
@@ -159,51 +51,54 @@ export class RealmRepo {
 
     getRealmImage(realmName) {
         if (realmName in this.realms) {
-            return this.realms[realmName]["realm_image"];
-        }
-        else {
-            return this.unknown["realm_image"];
+            return this.realms[realmName].image;
+        } else {
+            return this.unknown.image;
         }
     }
 
     getRealmImagePath(realmName) {
         let image;
         if (realmName in this.realms) {
-            image = this.realms[realmName]["realm_image"];
-        }
-        else {
-            image = this.unknown["realm_image"];
+            image = this.realms[realmName].image;
+        } else {
+            image = this.unknown.image;
         }
         return this.REALM_IMAGE_PATH + image;
     }
 
     getOfferingName(realmName) {
         if (realmName in this.realms) {
-            return this.realms[realmName]["offering_name"];
-        }
-        else {
-            return this.unknown["offering_name"];
+            return this.realms[realmName].offeringName;
+        } else {
+            return this.unknown.offeringName;
         }
     }
 
     getOfferingImage(realmName) {
         if (realmName in this.realms) {
-            return this.realms[realmName]["offering_image"];
-        }
-        else {
-            return this.unknown["offering_image"];
+            return this.realms[realmName].offeringImage;
+        } else {
+            return this.unknown.offeringImage;
         }
     }
 
     getOfferingImagePath(realmName) {
         let image;
         if (realmName in this.realms) {
-            image = this.realms[realmName]["offering_image"];
-        }
-        else {
-            image = this.unknown["offering_image"];
+            image = this.realms[realmName].offeringImage;
+        } else {
+            image = this.unknown.offeringImage;
         }
         return this.OFFERING_IMAGE_PATH + image;
     }
 }
 
+class Realm {
+    constructor(name, image, offeringName, offeringImage) {
+        this.name = name;
+        this.image = image;
+        this.offeringName = offeringName;
+        this.offeringImage = offeringImage;
+    }
+}


### PR DESCRIPTION
This PR adds fields for an offering icon and Offering name. The fields will be populated by the values for the Offering related to the currently selected Realm. 

**Context**
Each Realm in DBD has an Offering that can be used by the player to choose a given map for the next match. Each Offering has an icon and a name. 

